### PR TITLE
Move matplotlib and seaborn to optional [plot] extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,17 @@ requires-python = ">=3.8"
 
 dependencies = [
     "numpy",
-    "matplotlib",
-    "seaborn",
     "pandas",
     "tqdm",
     # add other dependencies as needed
 ]
 
 [project.optional-dependencies]
+plot = [
+    "matplotlib",
+    "seaborn",
+]
+
 docs = [
     "sphinx",
     "sphinxawesome-theme",


### PR DESCRIPTION
These are only needed for visualization utilities, not for the core scoring/ranking functionality used at runtime.

Install with: pip install pm-rank[plot]