### PR TITLE
Move matplotlib/seaborn to optional [plot] extra with import guards

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,6 @@ requires-python = ">=3.10"
 
 dependencies = [
     "numpy",
-    "matplotlib",
-    "seaborn",
     "pandas",
     "tqdm",
     "pydantic>=2.0",
@@ -19,6 +17,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+plot = [
+    "matplotlib",
+    "seaborn",
+]
+
 docs = [
     "sphinx",
     "sphinxawesome-theme",

--- a/src/pm_rank/model/calibration.py
+++ b/src/pm_rank/model/calibration.py
@@ -22,7 +22,6 @@ import numpy as np
 from typing import Literal, List
 from pm_rank.data.base import ForecastProblem
 from pm_rank.model.utils import get_logger
-from pm_rank.plotting.plot_reliability_diagram import plot_reliability_diagram
 import logging
 
 
@@ -203,11 +202,13 @@ class CalibrationMetric:
         return (forecaster_scores, forecaster_ranking) if include_scores else forecaster_ranking
 
     def plot(self, name: str, title: str = "Reliability diagram", save_path: str = None, figsize: tuple[float, float] = (4,4), percent: bool = True):
+        from pm_rank.plotting.plot_reliability_diagram import plot_reliability_diagram
+
         if not self._fitted:
             raise ValueError("CalibrationMetric must be fitted before plotting")
         if name not in self._fitted_info:
             raise ValueError(f"Forecaster {name} not found in fitted info")
-        
+
         bin_centers, bin_widths, conf, acc, counts = self._fitted_info[name]
 
         ece = _calculate_ece(conf, acc, counts, counts.sum())

--- a/src/pm_rank/model/irt/_irt_utils.py
+++ b/src/pm_rank/model/irt/_irt_utils.py
@@ -1,16 +1,23 @@
 from typing import Dict
 
 import torch
-import matplotlib.pyplot as plt
 
 def plot_posterior_samples(posterior_samples: Dict[str, torch.Tensor], base_path: str):
     """
     Plot histograms of posterior samples for theta, a, b, and p parameters.
     Creates 4 separate PNG files.
-    
+
     Args:
         posterior_samples: Dictionary of posterior samples from MCMC
     """
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError as e:
+        raise ImportError(
+            "matplotlib is required for plotting. "
+            "Install it with: pip install pm-rank[plot]"
+        ) from e
+
     base_path = "/net/scratch2/listar2000/pm_ranking/model/irt/images"
     
     # Plot theta samples (first 10)

--- a/src/pm_rank/nightly/plot.py
+++ b/src/pm_rank/nightly/plot.py
@@ -1,7 +1,14 @@
 import pandas as pd
-import matplotlib.pyplot as plt
 import numpy as np
-import seaborn as sns
+
+try:
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+except ImportError as e:
+    raise ImportError(
+        "matplotlib and seaborn are required for plotting utilities. "
+        "Install them with: pip install pm-rank[plot]"
+    ) from e
 
 # Set theme and font styling (following plot_recall_rate_histogram.py)
 sns.set_theme(style="ticks")

--- a/src/pm_rank/nightly/plot_timestamp.py
+++ b/src/pm_rank/nightly/plot_timestamp.py
@@ -1,9 +1,16 @@
 import pandas as pd
-import matplotlib.pyplot as plt
 import numpy as np
-import seaborn as sns
 from datetime import timedelta
 from pm_rank.nightly.utils import calculate_time_to_last_submission, assign_time_bins
+
+try:
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+except ImportError as e:
+    raise ImportError(
+        "matplotlib and seaborn are required for plotting utilities. "
+        "Install them with: pip install pm-rank[plot]"
+    ) from e
 
 # Set theme and font styling (following plot_recall_rate_histogram.py)
 sns.set_theme(style="ticks")

--- a/src/pm_rank/plotting/plot_correlations_multiple_metrics.py
+++ b/src/pm_rank/plotting/plot_correlations_multiple_metrics.py
@@ -1,13 +1,21 @@
+import numpy as np
+
 from pm_rank.model.bradley_terry import GeneralizedBT
 from pm_rank.model.average_return import AverageReturn
 from pm_rank.model.scoring_rule import BrierScoringRule
 from pm_rank.model.irt import IRTModel, SVIConfig
 from pm_rank.data.loaders import GJOChallengeLoader
-import matplotlib.pyplot as plt
-import seaborn as sns
-import numpy as np
-from matplotlib.patches import Rectangle
 from pm_rank.model.utils import spearman_correlation, kendall_correlation
+
+try:
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+    from matplotlib.patches import Rectangle
+except ImportError as e:
+    raise ImportError(
+        "matplotlib and seaborn are required for plotting utilities. "
+        "Install them with: pip install pm-rank[plot]"
+    ) from e
 
 
 def _get_all_rankings():

--- a/src/pm_rank/plotting/plot_crra_risks_curves.py
+++ b/src/pm_rank/plotting/plot_crra_risks_curves.py
@@ -7,9 +7,16 @@ In total, we plot (1 x 3) plots, where in each plot for a certain risk aversion 
 - lines: different forecasters (use different colors for each forecaster)
 - title: risk aversion level
 """
-import matplotlib.pyplot as plt
-import seaborn as sns
 from typing import Dict
+
+try:
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+except ImportError as e:
+    raise ImportError(
+        "matplotlib and seaborn are required for plotting utilities. "
+        "Install them with: pip install pm-rank[plot]"
+    ) from e
 
 from pm_rank.data.loaders import ProphetArenaChallengeLoader
 from pm_rank.model.average_return import AverageReturn

--- a/src/pm_rank/plotting/plot_reliability_diagram.py
+++ b/src/pm_rank/plotting/plot_reliability_diagram.py
@@ -1,6 +1,13 @@
 import numpy as np
-import matplotlib.pyplot as plt
-from matplotlib.patches import Rectangle
+
+try:
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Rectangle
+except ImportError as e:
+    raise ImportError(
+        "matplotlib is required for plotting utilities. "
+        "Install it with: pip install pm-rank[plot]"
+    ) from e
 
 plt.rcParams["font.family"] = "serif"
 plt.rcParams["font.serif"] = ["DejaVu Serif"]


### PR DESCRIPTION
## Summary
- Moves `matplotlib` and `seaborn` from core `dependencies` to a new `[plot]` optional extra in `pyproject.toml`
- Adds `try/except ImportError` guards with helpful install messages in all 5 plotting modules
- Defers `plot_reliability_diagram` import in `CalibrationMetric.plot()` to avoid breaking core imports
- Moves `matplotlib` import inside `plot_posterior_samples()` in `_irt_utils.py`

Fixes #12 — the original PR only updated `pyproject.toml` but missed the import guards, which caused `import pm_rank` to fail since `calibration.py` (a core module) imported from the plotting subpackage at the top level.

Users can install plotting dependencies with: `pip install pm-rank[plot]`

## Test plan
- [x] All 71 tests pass without matplotlib/seaborn installed
- [x] `import pm_rank` works correctly without plotting dependencies
- [x] Plotting modules raise clear `ImportError` with install instructions when dependencies are missing

https://claude.ai/code/session_017rw8SkiPTG1TF1dc6jzLvp